### PR TITLE
docs: Make references more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-# Incubation Labs
+# DIF Labs
 
-A place where we can all build together. 
+A place where we can all build together.
 
-See our [charter](./docs/charter.md). 
+See our [charter](./docs/charter.md).
+
+## Proposals
+
+| Proposal Name | Leads | Goal | Proposal Link |
+|---------------|-------|------|---------------|
+| Bitcoin Ordinals Verifiable Credentials Framework | Brian Richter | Establish a standardized framework for implementing verifiable credentials on Bitcoin using Ordinal inscriptions. | [Read the proposal](./proposals/btco-vc/btco_vc_proposal.md) |
+| Linked Claims | Golda Velez, Agnes Koinange, Phil Long | Build progressive trust through combining attestations and release the high-level specification for LinkedClaims to further the LinkedTrust project. | [Read the proposal](./proposals/linked_claims/001_proposal.md) |
+| VerAnon | Alex Hache | Introduce a protocol for anonymous personhood verification using Semaphore, a zero-knowledge group membership protocol. | [Read the proposal](./proposals/veranon/veranon_proposal.md) |

--- a/docs/charter.md
+++ b/docs/charter.md
@@ -1,17 +1,18 @@
-# Incubation Labs Charter
+# DIF Labs Charter
 
 ## Status
 
 |        |                                                                              |
 |--------|------------------------------------------------------------------------------|
-| Name   | Incubation Labs                                                              |
-| Initial Chairs | Andor Kesselman, Ankur Banerjee                                      |
-| Status | PROPOSED                                                                     |
-| Repo   | [https://github.com/decentralized-identity/incubation-labs](https://github.com/decentralized-identity/incubation-labs) |
+| Name   | DIF Labs                                                              |
+| Initial Chairs | Andor Kesselman, Ankur Banerjee, 
+Daniel Thompson-Yvetot                                      |
+| Status | ACCEPTED                                                                     |
+| Repo   | [https://github.com/decentralized-identity/labs](https://github.com/decentralized-identity/labs) |
 
 ## Scope
 
-The Incubation Labs Working Group (ILWG) serves as an incubation
+The DIF Labs Working Group serves as an incubation
 environment for decentralized identity-based user applications and spec
 implementations. The WG provides an IP-safe environment for general
 implementation-related discussion, and allows participants to propose and

--- a/mentors.md
+++ b/mentors.md
@@ -1,5 +1,0 @@
-Here's the provided JSON data formatted into a markdown table:
-
-| Name          | LinkedIn                                | Email             | Company          | Start Date  | Description                                                                                                            | Domain Expertise                                                                  |
-|---------------|-----------------------------------------|-------------------|------------------|-------------|------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|
-| Andor Kesselman | [andorsk](https://www.linkedin.com/in/andorsk/) | andor@andor.us    | Henosisknot LLC  | 2024-06-10  | Co-chair of the TSC, Chair of DWN Working Item, Co-Chair of the Trust Registry Task Force at Trust Over IP              | graph theory, startups, computer vision, decentralized web nodes, trust registries, full_stack |

--- a/website/content/about.md
+++ b/website/content/about.md
@@ -4,20 +4,21 @@ draft = false
 title = 'About'
 +++
 
-# Incubation Labs Charter
+# DIF Labs Charter
 
 ## Status
 
 |        |                                                                              |
 |--------|------------------------------------------------------------------------------|
-| Name   | Incubation Labs                                                              |
-| Initial Chairs | Andor Kesselman, Ankur Banerjee                                      |
-| Status | APPROVED                                                                     |
-| Repo   | [https://github.com/decentralized-identity/incubation-labs](https://github.com/decentralized-identity/labs) |
+| Name   | DIF Labs                                                              |
+| Initial Chairs | Andor Kesselman, Ankur Banerjee, 
+Daniel Thompson-Yvetot                                      |
+| Status | ACCEPTED                                                                     |
+| Repo   | [https://github.com/decentralized-identity/labs](https://github.com/decentralized-identity/labs) |
 
 ## Scope
 
-The Incubation Labs Working Group (ILWG) serves as an incubation
+The DIF Labs Working Group serves as an incubation
 environment for decentralized identity-based user applications and spec
 implementations. The WG provides an IP-safe environment for general
 implementation-related discussion, and allows participants to propose and


### PR DESCRIPTION
- Added proposals table on main page
- Changed outdated references to "Incubation Labs" (n.b. I did not do this in the launch blog post URL; content in that blog post does talk about "DIF Labs")
- Removed the mentors Markdown file since it's tracked on the JSON file now for the website anyway.