### PR TITLE
style: Make links more readable

### DIFF
--- a/website/themes/diflabs/assets/css/main.css
+++ b/website/themes/diflabs/assets/css/main.css
@@ -213,8 +213,8 @@ a {
 }
 
 a:visited {
-    color: #FFCC00; /* Change visited link color to yellow */
-    border-bottom: 2px dashed #FFCC00; /* Change underline color for visited links */
+    color: #ADD8E6; /* Change visited link color to yellow */
+    border-bottom: 2px dashed #ADD8E6; /* Change underline color for visited links */
 }
 
 a:hover {

--- a/website/themes/diflabs/assets/css/main.css
+++ b/website/themes/diflabs/assets/css/main.css
@@ -42,14 +42,13 @@ nav {
 }
 
 nav a {
-    color: #66FF66;
+    color: #66FF66; /* Change link color to light green */
     text-decoration: none;
-    fill: #66FF66;
     font-size: 1.2em;
 }
 
 nav a:hover {
-    color: #FFCC00;
+    color: #FFCC00; /* Change hover color to yellow */
 }
 
 .animation-banner {
@@ -207,10 +206,17 @@ footer {
     margin-right: 5px;
 }
 
+a {
+    color: #66FF66; /* Change link color to light green */
+    text-decoration: none;
+}
 
+a:hover {
+    color: #FFCC00; /* Change hover color to yellow */
+}
 
 nav a:hover {
-    color: #00ff00;
+    color: #FFCC00;
 }
 
 button.hamburger {

--- a/website/themes/diflabs/assets/css/main.css
+++ b/website/themes/diflabs/assets/css/main.css
@@ -209,10 +209,17 @@ footer {
 a {
     color: #66FF66; /* Change link color to light green */
     text-decoration: none;
+    border-bottom: 2px dashed #66FF66; /* Add dashed underline */
+}
+
+a:visited {
+    color: #FFCC00; /* Change visited link color to yellow */
+    border-bottom: 2px dashed #FFCC00; /* Change underline color for visited links */
 }
 
 a:hover {
     color: #FFCC00; /* Change hover color to yellow */
+    border-bottom: 2px dashed #FFCC00; /* Change underline color on hover */
 }
 
 nav a:hover {

--- a/website/themes/diflabs/assets/css/main.css
+++ b/website/themes/diflabs/assets/css/main.css
@@ -164,7 +164,7 @@ footer {
 
 .filter-buttons {
     display: flex;
-    ga  p: 20px;
+    gap: 20px;
     margin-bottom: 20px;
 }
 


### PR DESCRIPTION
<img width="964" alt="Screenshot 2025-01-28 at 18 06 02" src="https://github.com/user-attachments/assets/bef987ad-ed12-4fc2-bc4c-ccb785601238" />

Links in navbar are fine, but the ones in the rest of the site are unreadable because of blue on black or purple on black. This CSS update makes the links more readable by using:

- Unvisited links: Light Green (#66FF66)
- Visited links: Light Blue (#ADD8E6)
- Hover links: Yellow (#FFFF00)