### PR TITLE
btco-vc has been renamed to ordinals plus

### DIFF
--- a/website/static/data/directory.json
+++ b/website/static/data/directory.json
@@ -90,7 +90,7 @@
     "leads": [
         {
             "name": "Brian Richter",
-            "role": "Bitcoin Ordinals Verifiable Credentials",
+            "role": "Ordinals Plus",
             "img": "/data/profiles/brian_richter.jpg",
             "profile_url": "https://www.linkedin.com/in/brianrichter3/?originalSubdomain=ca"
         },

--- a/website/static/data/projects.json
+++ b/website/static/data/projects.json
@@ -1,6 +1,6 @@
 [
     {
-        "title": "Bitcoin Ordinals Verifiable Credentials Framework",
+        "title": "Ordinals Plus",
         "description": "Establish a standardized framework for implementing verifiable credentials on Bitcoin using Ordinal inscriptions.",
         "long_description": "This proposal outlines a framework built on the did:btco method, associating DIDs with specific ordinals for tamper-proof digital artifacts. By leveraging Bitcoin’s security and decentralization, it aims to enable on-chain verifiable credentials for use cases such as event tickets, ownership records, and AI-generated content. Emphasis is on privacy, scalability, and seamless integration with existing W3C VC and DID standards.",
         "timeline": "November 28, 2024 - January 31, 2025",


### PR DESCRIPTION
Brian has rebranded btco-vc to ordinals plus. This reflects those changes.

