### PR TITLE
Add Latest Post Banner to Homepage

### DIFF
--- a/website/themes/diflabs/layouts/index.html
+++ b/website/themes/diflabs/layouts/index.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+{{ partial "latest-post-banner" . }}
 <div class="container">
     <div class="filter-buttons">
     </div>

--- a/website/themes/diflabs/layouts/partials/head.html
+++ b/website/themes/diflabs/layouts/partials/head.html
@@ -1,6 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<link rel="stylesheet" href="/css/banner.css">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
 {{ partialCached "head/css.html" . }}
 {{ partialCached "head/js.html" . }}

--- a/website/themes/diflabs/layouts/partials/latest-post-banner.html
+++ b/website/themes/diflabs/layouts/partials/latest-post-banner.html
@@ -1,13 +1,11 @@
 {{ $latestPost := index (where .Site.RegularPages "Section" "posts") 0 }}
 {{ if $latestPost }}
 <div class="latest-post-banner">
-    <div class="banner-content">
+    <a href="{{ $latestPost.RelPermalink }}" class="banner-content">
         <span class="latest-text">Latest Post</span>
         <span class="new-badge">NEW</span>
-        <a href="{{ $latestPost.RelPermalink }}">
-            {{ $latestPost.Title }}
-            <span class="banner-date">{{ $latestPost.Date.Format "Jan 2, 2006" }}</span>
-        </a>
-    </div>
+        <span class="post-title">{{ $latestPost.Title }}</span>
+        <span class="banner-date">{{ $latestPost.Date.Format "Jan 2, 2006" }}</span>
+    </a>
 </div>
 {{ end }} 

--- a/website/themes/diflabs/layouts/partials/latest-post-banner.html
+++ b/website/themes/diflabs/layouts/partials/latest-post-banner.html
@@ -1,0 +1,13 @@
+{{ $latestPost := index (where .Site.RegularPages "Section" "posts") 0 }}
+{{ if $latestPost }}
+<div class="latest-post-banner">
+    <div class="banner-content">
+        <span class="latest-text">Latest Post</span>
+        <span class="new-badge">NEW</span>
+        <a href="{{ $latestPost.RelPermalink }}">
+            {{ $latestPost.Title }}
+            <span class="banner-date">{{ $latestPost.Date.Format "Jan 2, 2006" }}</span>
+        </a>
+    </div>
+</div>
+{{ end }} 

--- a/website/themes/diflabs/static/css/banner.css
+++ b/website/themes/diflabs/static/css/banner.css
@@ -12,27 +12,36 @@
     align-items: center;
     justify-content: center;
     gap: 1rem;
+    border: 2px solid #00ff00;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
+.banner-content:hover {
+    background-color: rgba(0, 255, 0, 0.1);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 .latest-text {
     color: #00ff00;
     font-size: 0.9rem;
-    font-weight: 500;
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.5px;
+    padding-top: 0.25rem;
 }
 
-.latest-post-banner a {
-    color: #333;
-    text-decoration: none;
+.post-title {
+    color: #00ff00;
     font-weight: 500;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
 }
 
-.latest-post-banner a:hover {
-    color: #007bff;
+.banner-content:hover .post-title {
+    color: #00ff00;
 }
 
 @keyframes pulse {
@@ -51,7 +60,7 @@
 }
 
 .new-badge {
-    background-color: #28a745;
+    background-color: #00ff00;
     color: white;
     padding: 0.25rem 0.5rem;
     border-radius: 3px;

--- a/website/themes/diflabs/static/css/banner.css
+++ b/website/themes/diflabs/static/css/banner.css
@@ -1,0 +1,67 @@
+.latest-post-banner {
+    padding: 0.75rem 1rem;
+    text-align: center;
+    position: relative;
+    width: 100%;
+}
+
+.banner-content {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.latest-text {
+    color: #00ff00;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.latest-post-banner a {
+    color: #333;
+    text-decoration: none;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.latest-post-banner a:hover {
+    color: #007bff;
+}
+
+@keyframes pulse {
+    0% {
+        transform: scale(1);
+        opacity: 1;
+    }
+    50% {
+        transform: scale(1.05);
+        opacity: 0.8;
+    }
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+.new-badge {
+    background-color: #28a745;
+    color: white;
+    padding: 0.25rem 0.5rem;
+    border-radius: 3px;
+    font-size: 0.8rem;
+    font-weight: bold;
+    animation: pulse 2s infinite;
+}
+
+.banner-date {
+    color: #00ff00;
+    font-size: 0.9rem;
+    font-weight: normal;
+} 


### PR DESCRIPTION
This PR adds a dynamic banner to showcase the most recent blog post, featuring:

- Interactive banner with hover effects and full-area click target
- Consistent green (#00ff00) branding across all text elements
- Animated "NEW" badge with pulsing effect
- Clean bordered design that highlights latest content
- Automatic updates based on most recent post in /posts directory

Technical changes:
- Added latest-post-banner.html partial
- Added banner.css for styling
- Updated head.html to include new CSS
- Modified index.html to include banner partial

The banner improves content discovery by making the latest post immediately visible and accessible from the homepage.

![image](https://github.com/user-attachments/assets/0b6e8320-1b27-4eed-aa57-b6b37c72b70f)
